### PR TITLE
 Remove @jupyter namespace from the package name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lot of the components of this chat project come from
 ### Typescript package
 
 The typescript package is located in *packages/jupyter-chat* and builds an NPM
-package named `@jupyter/chat`.
+package named `chat-jupyter`.
 
 This package provides a frontend library (using react), and is intended to be
 used by a jupyterlab extension.
@@ -24,7 +24,7 @@ The Jupyterlab extension is located in *packages/jupyter-chat-extension*.
 It is composed of a Python package named `jupyter_chat_extension`
 for the server side and a NPM package named `jupyter-chat-extension`.
 
-This extension is an implementation of the `@jupyter/chat` package, relying on
+This extension is an implementation of the `chat-jupyter` package, relying on
 websocket for the communication between server and front end.
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@jupyter/chat-root",
+    "name": "chat-jupyter-root",
     "version": "0.1.0",
     "description": "A chat package for Jupyterlab extension",
     "private": true,

--- a/packages/jupyter-chat-extension/package.json
+++ b/packages/jupyter-chat-extension/package.json
@@ -53,12 +53,12 @@
         "watch:src": "tsc -w --sourceMap"
     },
     "dependencies": {
-        "chat-jupyter": "^0.1.0",
         "@jupyterlab/apputils": "^4.0.5",
         "@jupyterlab/coreutils": "^6.0.5",
         "@jupyterlab/rendermime": "^4.0.5",
         "@jupyterlab/services": "^7.0.5",
-        "@lumino/coreutils": "^2.1.2"
+        "@lumino/coreutils": "^2.1.2",
+        "chat-jupyter": "^0.1.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/packages/jupyter-chat-extension/package.json
+++ b/packages/jupyter-chat-extension/package.json
@@ -53,7 +53,7 @@
         "watch:src": "tsc -w --sourceMap"
     },
     "dependencies": {
-        "@jupyter/chat": "^0.1.0",
+        "chat-jupyter": "^0.1.0",
         "@jupyterlab/apputils": "^4.0.5",
         "@jupyterlab/coreutils": "^6.0.5",
         "@jupyterlab/rendermime": "^4.0.5",

--- a/packages/jupyter-chat-extension/src/handlers/websocket-handler.ts
+++ b/packages/jupyter-chat-extension/src/handlers/websocket-handler.ts
@@ -8,8 +8,8 @@ import { ServerConnection } from '@jupyterlab/services';
 import { UUID } from '@lumino/coreutils';
 
 import { requestAPI } from './handler';
-import { ChatModel, IChatModel } from '@jupyter/chat';
-import { IChatHistory, IMessage, INewMessage } from '@jupyter/chat';
+import { ChatModel, IChatModel } from 'chat-jupyter';
+import { IChatHistory, IMessage, INewMessage } from 'chat-jupyter';
 
 const CHAT_SERVICE_URL = 'api/chat';
 

--- a/packages/jupyter-chat-extension/src/index.ts
+++ b/packages/jupyter-chat-extension/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { ReactWidget, IThemeManager } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
-import { buildChatSidebar, buildErrorWidget } from '@jupyter/chat';
+import { buildChatSidebar, buildErrorWidget } from 'chat-jupyter';
 
 import { WebSocketHandler } from './handlers/websocket-handler';
 

--- a/packages/jupyter-chat-extension/ui-tests/package.json
+++ b/packages/jupyter-chat-extension/ui-tests/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@jupyter/chat-ui-tests",
+    "name": "jupyter-chat-extension-ui-tests",
     "version": "1.0.0",
-    "description": "JupyterLab @jupyter/chat Integration Tests",
+    "description": "jupyter-chat-extension Integration Tests",
     "private": true,
     "scripts": {
         "start": "jupyter lab --config jupyter_server_test_config.py",

--- a/packages/jupyter-chat/package.json
+++ b/packages/jupyter-chat/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@jupyter/chat",
+    "name": "chat-jupyter",
     "version": "0.1.0",
     "description": "A package that provides UI components that can be used to create a chat in a Jupyterlab extension.",
     "keywords": [

--- a/packages/jupyter-chat/schema/plugin.json
+++ b/packages/jupyter-chat/schema/plugin.json
@@ -1,8 +1,0 @@
-{
-  "jupyter.lab.shortcuts": [],
-  "title": "@jupyter/chat",
-  "description": "@jupyter/chat settings.",
-  "type": "object",
-  "properties": {},
-  "additionalProperties": false
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,55 +2261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/chat-root@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@jupyter/chat-root@workspace:."
-  dependencies:
-    lerna: ^6.4.1
-  languageName: unknown
-  linkType: soft
-
-"@jupyter/chat@^0.1.0, @jupyter/chat@workspace:packages/jupyter-chat":
-  version: 0.0.0-use.local
-  resolution: "@jupyter/chat@workspace:packages/jupyter-chat"
-  dependencies:
-    "@emotion/react": ^11.10.5
-    "@emotion/styled": ^11.10.5
-    "@jupyterlab/apputils": ^4.0.5
-    "@jupyterlab/rendermime": ^4.0.5
-    "@jupyterlab/ui-components": ^4.0.5
-    "@lumino/disposable": ^2.1.2
-    "@lumino/signaling": ^2.1.2
-    "@mui/icons-material": ^5.11.0
-    "@mui/material": ^5.11.0
-    "@types/jest": ^29.2.0
-    "@types/json-schema": ^7.0.11
-    "@types/react": ^18.2.0
-    "@types/react-addons-linked-state-mixin": ^0.14.22
-    "@types/react-dom": ^18.2.0
-    "@typescript-eslint/eslint-plugin": ^6.1.0
-    "@typescript-eslint/parser": ^6.1.0
-    css-loader: ^6.7.1
-    eslint: ^8.36.0
-    eslint-config-prettier: ^8.8.0
-    eslint-plugin-prettier: ^5.0.0
-    jest: ^29.2.0
-    npm-run-all: ^4.1.5
-    prettier: ^3.0.0
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rimraf: ^5.0.1
-    source-map-loader: ^1.0.2
-    style-loader: ^3.3.1
-    stylelint: ^15.10.1
-    stylelint-config-recommended: ^13.0.0
-    stylelint-config-standard: ^34.0.0
-    stylelint-csstree-validator: ^3.0.0
-    stylelint-prettier: ^4.0.0
-    typescript: ~5.0.2
-  languageName: unknown
-  linkType: soft
-
 "@jupyter/react-components@npm:^0.15.2":
   version: 0.15.3
   resolution: "@jupyter/react-components@npm:0.15.3"
@@ -5766,6 +5717,55 @@ __metadata:
   checksum: 6fd5da1f5d18ff5712c1e0aed41da200d7c51c28f11b36ee3c7b483f3696dabc08927fc6b227735eb8f0e1215c9a8abd8154637f3eff8cada5959df7f58b024d
   languageName: node
   linkType: hard
+
+"chat-jupyter-root@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "chat-jupyter-root@workspace:."
+  dependencies:
+    lerna: ^6.4.1
+  languageName: unknown
+  linkType: soft
+
+"chat-jupyter@^0.1.0, chat-jupyter@workspace:packages/jupyter-chat":
+  version: 0.0.0-use.local
+  resolution: "chat-jupyter@workspace:packages/jupyter-chat"
+  dependencies:
+    "@emotion/react": ^11.10.5
+    "@emotion/styled": ^11.10.5
+    "@jupyterlab/apputils": ^4.0.5
+    "@jupyterlab/rendermime": ^4.0.5
+    "@jupyterlab/ui-components": ^4.0.5
+    "@lumino/disposable": ^2.1.2
+    "@lumino/signaling": ^2.1.2
+    "@mui/icons-material": ^5.11.0
+    "@mui/material": ^5.11.0
+    "@types/jest": ^29.2.0
+    "@types/json-schema": ^7.0.11
+    "@types/react": ^18.2.0
+    "@types/react-addons-linked-state-mixin": ^0.14.22
+    "@types/react-dom": ^18.2.0
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
+    css-loader: ^6.7.1
+    eslint: ^8.36.0
+    eslint-config-prettier: ^8.8.0
+    eslint-plugin-prettier: ^5.0.0
+    jest: ^29.2.0
+    npm-run-all: ^4.1.5
+    prettier: ^3.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rimraf: ^5.0.1
+    source-map-loader: ^1.0.2
+    style-loader: ^3.3.1
+    stylelint: ^15.10.1
+    stylelint-config-recommended: ^13.0.0
+    stylelint-config-standard: ^34.0.0
+    stylelint-csstree-validator: ^3.0.0
+    stylelint-prettier: ^4.0.0
+    typescript: ~5.0.2
+  languageName: unknown
+  linkType: soft
 
 "child_process@npm:~1.0.2":
   version: 1.0.2
@@ -9694,7 +9694,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyter-chat-extension@workspace:packages/jupyter-chat-extension"
   dependencies:
-    "@jupyter/chat": ^0.1.0
     "@jupyterlab/apputils": ^4.0.5
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.5
@@ -9708,6 +9707,7 @@ __metadata:
     "@types/react-dom": ^18.2.0
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
+    chat-jupyter: ^0.1.0
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0


### PR DESCRIPTION
This change is temporary and should be reverted when the project become an official Jupyter project