### PR TITLE
Add the @jupyter namespace to the NPM chat package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lot of the components of this chat project come from
 ### Typescript package
 
 The typescript package is located in *packages/jupyter-chat* and builds an NPM
-package named `chat-jupyter`.
+package named `@jupyter/chat`.
 
 This package provides a frontend library (using react), and is intended to be
 used by a jupyterlab extension to create a chat.
@@ -22,7 +22,7 @@ used by a jupyterlab extension to create a chat.
 
 #### Chat extension based on shared document: *packages/jupyterlab-collaborative-chat*
 
-This extension is an implementation of the `chat-jupyter` package, relying on
+This extension is an implementation of the `@jupyter/chat` package, relying on
 shared document (see [jupyter_ydoc](https://github.com/jupyter-server/jupyter_ydoc)).
 
 It is composed of:
@@ -33,7 +33,7 @@ It is composed of:
 
 #### Chat extension based on websocket: *packages/jupyterlab-ws-chat*
 
-This extension is an implementation of the `chat-jupyter` package, relying on
+This extension is an implementation of the `@jupyter/chat` package, relying on
 websocket for the communication between server and front end.
 
 It is composed of a Python package named `jupyterlab_ws_chat`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "chat-jupyter-root",
+    "name": "jupyter-chat-root",
     "version": "0.1.0",
     "description": "A chat package for Jupyterlab extension",
     "private": true,
@@ -26,7 +26,7 @@
     ],
     "scripts": {
         "build": "lerna run build --stream",
-        "build:core": "lerna run build --stream --scope \"chat-jupyter\"",
+        "build:core": "lerna run build --stream --scope \"@jupyter/chat\"",
         "build:collaborative": "lerna run build --scope=jupyterlab-collaborative-chat --include-filtered-dependencies",
         "build:ws": "lerna run build --scope=jupyterlab-ws-chat --include-filtered-dependencies",
         "build:prod": "lerna run build:prod --stream",

--- a/packages/jupyter-chat/package.json
+++ b/packages/jupyter-chat/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "chat-jupyter",
+    "name": "@jupyter/chat",
     "version": "0.1.0",
     "description": "A package that provides UI components that can be used to create a chat in a Jupyterlab extension.",
     "keywords": [

--- a/packages/jupyterlab-collaborative-chat/package.json
+++ b/packages/jupyterlab-collaborative-chat/package.json
@@ -57,6 +57,7 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
+        "@jupyter/chat": "^0.1.0",
         "@jupyter/collaboration": "^2.0.11",
         "@jupyter/docprovider": "^2.0.11",
         "@jupyterlab/application": "^4.0.0",
@@ -70,7 +71,6 @@
         "@jupyterlab/translation": "^4.0.0",
         "@lumino/coreutils": "^2.0.0",
         "@lumino/signaling": "^2.0.0",
-        "chat-jupyter": "0.1.0",
         "y-protocols": "^1.0.5",
         "yjs": "^13.5.40"
     },

--- a/packages/jupyterlab-collaborative-chat/src/factory.ts
+++ b/packages/jupyterlab-collaborative-chat/src/factory.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ChatWidget, IChatModel, IConfig } from 'chat-jupyter';
+import { ChatWidget, IChatModel, IConfig } from '@jupyter/chat';
 import { IThemeManager } from '@jupyterlab/apputils';
 import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';

--- a/packages/jupyterlab-collaborative-chat/src/index.ts
+++ b/packages/jupyterlab-collaborative-chat/src/index.ts
@@ -3,6 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { chatIcon } from '@jupyter/chat';
 import { IGlobalAwareness } from '@jupyter/collaboration';
 import { ICollaborativeDrive } from '@jupyter/docprovider';
 import {
@@ -26,7 +27,6 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { Contents } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-import { chatIcon } from 'chat-jupyter';
 import { Awareness } from 'y-protocols/awareness';
 
 import {

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ChatModel, IChatMessage, INewMessage, IUser } from 'chat-jupyter';
+import { ChatModel, IChatMessage, INewMessage, IUser } from '@jupyter/chat';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { PartialJSONObject, UUID } from '@lumino/coreutils';

--- a/packages/jupyterlab-collaborative-chat/src/token.ts
+++ b/packages/jupyterlab-collaborative-chat/src/token.ts
@@ -3,10 +3,10 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { IConfig, chatIcon } from '@jupyter/chat';
 import { Token } from '@lumino/coreutils';
 import { ISignal } from '@lumino/signaling';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
-import { IConfig, chatIcon } from 'chat-jupyter';
 
 export const chatFileType: DocumentRegistry.IFileType = {
   name: 'chat',

--- a/packages/jupyterlab-collaborative-chat/src/widget.ts
+++ b/packages/jupyterlab-collaborative-chat/src/widget.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ChatWidget } from 'chat-jupyter';
+import { ChatWidget } from '@jupyter/chat';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 
 import { CollaborativeChatModel } from './model';

--- a/packages/jupyterlab-ws-chat/package.json
+++ b/packages/jupyterlab-ws-chat/package.json
@@ -54,13 +54,13 @@
         "watch:src": "tsc -w --sourceMap"
     },
     "dependencies": {
+        "@jupyter/chat": "^0.1.0",
         "@jupyterlab/apputils": "^4.0.0",
         "@jupyterlab/coreutils": "^6.0.0",
         "@jupyterlab/rendermime": "^4.0.0",
         "@jupyterlab/services": "^7.0.0",
         "@jupyterlab/settingregistry": "^4.0.0",
-        "@lumino/coreutils": "^2.0.0",
-        "chat-jupyter": "^0.1.0"
+        "@lumino/coreutils": "^2.0.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
+++ b/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
@@ -3,13 +3,18 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import {
+  ChatModel,
+  IChatHistory,
+  IChatModel,
+  IMessage,
+  INewMessage
+} from '@jupyter/chat';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 import { UUID } from '@lumino/coreutils';
 
 import { requestAPI } from './handler';
-import { ChatModel, IChatModel } from 'chat-jupyter';
-import { IChatHistory, IMessage, INewMessage } from 'chat-jupyter';
 
 const CHAT_SERVICE_URL = 'api/chat';
 

--- a/packages/jupyterlab-ws-chat/src/index.ts
+++ b/packages/jupyterlab-ws-chat/src/index.ts
@@ -3,6 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { buildChatSidebar, buildErrorWidget } from '@jupyter/chat';
 import {
   ILayoutRestorer,
   JupyterFrontEnd,
@@ -11,7 +12,6 @@ import {
 import { ReactWidget, IThemeManager } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { buildChatSidebar, buildErrorWidget } from 'chat-jupyter';
 
 import { WebSocketHandler } from './handlers/websocket-handler';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,6 +2274,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyter/chat@^0.1.0, @jupyter/chat@workspace:packages/jupyter-chat":
+  version: 0.0.0-use.local
+  resolution: "@jupyter/chat@workspace:packages/jupyter-chat"
+  dependencies:
+    "@emotion/react": ^11.10.5
+    "@emotion/styled": ^11.10.5
+    "@jupyterlab/apputils": ^4.0.0
+    "@jupyterlab/rendermime": ^4.0.0
+    "@jupyterlab/ui-components": ^4.0.0
+    "@lumino/disposable": ^2.0.0
+    "@lumino/signaling": ^2.0.0
+    "@mui/icons-material": ^5.11.0
+    "@mui/material": ^5.11.0
+    "@types/jest": ^29.2.0
+    "@types/json-schema": ^7.0.11
+    "@types/react": ^18.2.0
+    "@types/react-addons-linked-state-mixin": ^0.14.22
+    "@types/react-dom": ^18.2.0
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
+    clsx: ^2.1.0
+    css-loader: ^6.7.1
+    eslint: ^8.36.0
+    eslint-config-prettier: ^8.8.0
+    eslint-plugin-prettier: ^5.0.0
+    jest: ^29.2.0
+    npm-run-all: ^4.1.5
+    prettier: ^3.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rimraf: ^5.0.1
+    source-map-loader: ^1.0.2
+    style-loader: ^3.3.1
+    stylelint: ^15.10.1
+    stylelint-config-recommended: ^13.0.0
+    stylelint-config-standard: ^34.0.0
+    stylelint-csstree-validator: ^3.0.0
+    stylelint-prettier: ^4.0.0
+    typescript: ~5.0.2
+  languageName: unknown
+  linkType: soft
+
 "@jupyter/collaboration@npm:^2.0.11":
   version: 2.0.11
   resolution: "@jupyter/collaboration@npm:2.0.11"
@@ -5812,56 +5854,6 @@ __metadata:
   checksum: 6fd5da1f5d18ff5712c1e0aed41da200d7c51c28f11b36ee3c7b483f3696dabc08927fc6b227735eb8f0e1215c9a8abd8154637f3eff8cada5959df7f58b024d
   languageName: node
   linkType: hard
-
-"chat-jupyter-root@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "chat-jupyter-root@workspace:."
-  dependencies:
-    lerna: ^6.4.1
-  languageName: unknown
-  linkType: soft
-
-"chat-jupyter@0.1.0, chat-jupyter@^0.1.0, chat-jupyter@workspace:packages/jupyter-chat":
-  version: 0.0.0-use.local
-  resolution: "chat-jupyter@workspace:packages/jupyter-chat"
-  dependencies:
-    "@emotion/react": ^11.10.5
-    "@emotion/styled": ^11.10.5
-    "@jupyterlab/apputils": ^4.0.0
-    "@jupyterlab/rendermime": ^4.0.0
-    "@jupyterlab/ui-components": ^4.0.0
-    "@lumino/disposable": ^2.0.0
-    "@lumino/signaling": ^2.0.0
-    "@mui/icons-material": ^5.11.0
-    "@mui/material": ^5.11.0
-    "@types/jest": ^29.2.0
-    "@types/json-schema": ^7.0.11
-    "@types/react": ^18.2.0
-    "@types/react-addons-linked-state-mixin": ^0.14.22
-    "@types/react-dom": ^18.2.0
-    "@typescript-eslint/eslint-plugin": ^6.1.0
-    "@typescript-eslint/parser": ^6.1.0
-    clsx: ^2.1.0
-    css-loader: ^6.7.1
-    eslint: ^8.36.0
-    eslint-config-prettier: ^8.8.0
-    eslint-plugin-prettier: ^5.0.0
-    jest: ^29.2.0
-    npm-run-all: ^4.1.5
-    prettier: ^3.0.0
-    react: ^18.2.0
-    react-dom: ^18.2.0
-    rimraf: ^5.0.1
-    source-map-loader: ^1.0.2
-    style-loader: ^3.3.1
-    stylelint: ^15.10.1
-    stylelint-config-recommended: ^13.0.0
-    stylelint-config-standard: ^34.0.0
-    stylelint-csstree-validator: ^3.0.0
-    stylelint-prettier: ^4.0.0
-    typescript: ~5.0.2
-  languageName: unknown
-  linkType: soft
 
 "child_process@npm:~1.0.2":
   version: 1.0.2
@@ -9826,10 +9818,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jupyter-chat-root@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "jupyter-chat-root@workspace:."
+  dependencies:
+    lerna: ^6.4.1
+  languageName: unknown
+  linkType: soft
+
 "jupyterlab-collaborative-chat@workspace:packages/jupyterlab-collaborative-chat":
   version: 0.0.0-use.local
   resolution: "jupyterlab-collaborative-chat@workspace:packages/jupyterlab-collaborative-chat"
   dependencies:
+    "@jupyter/chat": ^0.1.0
     "@jupyter/collaboration": ^2.0.11
     "@jupyter/docprovider": ^2.0.11
     "@jupyterlab/application": ^4.0.0
@@ -9851,7 +9852,6 @@ __metadata:
     "@types/react-addons-linked-state-mixin": ^0.14.22
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    chat-jupyter: 0.1.0
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
@@ -9878,6 +9878,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyterlab-ws-chat@workspace:packages/jupyterlab-ws-chat"
   dependencies:
+    "@jupyter/chat": ^0.1.0
     "@jupyterlab/apputils": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
@@ -9892,7 +9893,6 @@ __metadata:
     "@types/react-dom": ^18.2.0
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    chat-jupyter: ^0.1.0
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0


### PR DESCRIPTION
Restore the `@jupyter` namespace in the name of the chat frontend package.

Fixes https://github.com/jupyterlab-contrib/jupyter-chat/issues/7