### PR TITLE
Improve ychat

### DIFF
--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -135,20 +135,28 @@ export function ChatMessages(props: ChatMessagesProps): JSX.Element {
       }}
       className={clsx(MESSAGES_BOX_CLASS)}
     >
-      {props.messages.map((message, i) => (
-        // extra div needed to ensure each bubble is on a new line
-        <Box key={i} sx={{ padding: 4 }} className={clsx(MESSAGE_CLASS)}>
-          <ChatMessageHeader
-            {...message.sender}
-            timestamp={timestamps[message.id]}
-            sx={{ marginBottom: 3 }}
-          />
-          <RendermimeMarkdown
-            rmRegistry={props.rmRegistry}
-            markdownStr={message.body}
-          />
-        </Box>
-      ))}
+      {props.messages.map((message, i) => {
+        let sender: IUser;
+        if (typeof message.sender === 'string') {
+          sender = { id: message.sender };
+        } else {
+          sender = message.sender;
+        }
+        return (
+          // extra div needed to ensure each bubble is on a new line
+          <Box key={i} sx={{ padding: 4 }} className={clsx(MESSAGE_CLASS)}>
+            <ChatMessageHeader
+              {...sender}
+              timestamp={timestamps[message.id]}
+              sx={{ marginBottom: 3 }}
+            />
+            <RendermimeMarkdown
+              rmRegistry={props.rmRegistry}
+              markdownStr={message.body}
+            />
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/packages/jupyter-chat/src/components/chat.tsx
+++ b/packages/jupyter-chat/src/components/chat.tsx
@@ -56,10 +56,17 @@ function ChatBody({
         setMessages([]);
         return;
       } else if (message.type === 'msg') {
-        setMessages((messageGroups: IChatMessage[]) => [
-          ...messageGroups,
-          message
-        ]);
+        setMessages((messageGroups: IChatMessage[]) => {
+          const msg = [...messageGroups];
+          let nextMsgIndex = messageGroups.findIndex(
+            msg => msg.time > message.time
+          );
+          if (nextMsgIndex === -1) {
+            nextMsgIndex = messageGroups.length;
+          }
+          msg.splice(nextMsgIndex, 0, message);
+          return msg;
+        });
       }
     }
 

--- a/packages/jupyter-chat/src/components/chat.tsx
+++ b/packages/jupyter-chat/src/components/chat.tsx
@@ -57,15 +57,32 @@ function ChatBody({
         return;
       } else if (message.type === 'msg') {
         setMessages((messageGroups: IChatMessage[]) => {
-          const msg = [...messageGroups];
-          let nextMsgIndex = messageGroups.findIndex(
+          const existingMessages = [...messageGroups];
+
+          const messageIndex = existingMessages.findIndex(
+            msg => msg.id === message.id
+          );
+          if (messageIndex > -1) {
+            // The message is an update of an existing one.
+            // Let's remove it (to avoid position conflict if timestamp has changed)
+            // and add the new one.
+            existingMessages.splice(messageIndex, 1);
+          }
+
+          // Find the first message that should be after this one.
+          let nextMsgIndex = existingMessages.findIndex(
             msg => msg.time > message.time
           );
           if (nextMsgIndex === -1) {
-            nextMsgIndex = messageGroups.length;
+            // There is no message after this one, so let's insert the message at
+            // the end.
+            nextMsgIndex = existingMessages.length;
           }
-          msg.splice(nextMsgIndex, 0, message);
-          return msg;
+
+          // Insert the message.
+          existingMessages.splice(nextMsgIndex, 0, message);
+
+          return existingMessages;
         });
       }
     }

--- a/packages/jupyter-chat/src/components/rendermime-markdown.tsx
+++ b/packages/jupyter-chat/src/components/rendermime-markdown.tsx
@@ -15,6 +15,7 @@ const RENDERMIME_MD_CLASS = 'jp-chat-rendermime-markdown';
 type RendermimeMarkdownProps = {
   markdownStr: string;
   rmRegistry: IRenderMimeRegistry;
+  appendContent?: boolean;
 };
 
 /**
@@ -29,6 +30,7 @@ function escapeLatexDelimiters(text: string) {
 }
 
 function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
+  const appendContent = props.appendContent || false;
   const [renderedContent, setRenderedContent] = useState<HTMLElement | null>(
     null
   );
@@ -69,9 +71,12 @@ function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
 
   return (
     <div ref={containerRef} className={RENDERMIME_MD_CLASS}>
-      {renderedContent && (
-        <div ref={node => node && node.appendChild(renderedContent)} />
-      )}
+      {renderedContent &&
+        (appendContent ? (
+          <div ref={node => node && node.appendChild(renderedContent)} />
+        ) : (
+          <div ref={node => node && node.replaceChildren(renderedContent)} />
+        ))}
     </div>
   );
 }

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -34,16 +34,6 @@ export interface IChatModel extends IDisposable {
   get incomingMessage(): ISignal<IChatModel, IMessage>;
 
   /**
-   * The signal emitted when a message is updated.
-   */
-  get messageUpdated(): ISignal<IChatModel, IMessage>;
-
-  /**
-   * The signal emitted when a message is updated.
-   */
-  get messageDeleted(): ISignal<IChatModel, IMessage>;
-
-  /**
    * Send a message, to be defined depending on the chosen technology.
    * Default to no-op.
    *
@@ -135,20 +125,6 @@ export class ChatModel implements IChatModel {
   }
 
   /**
-   * The signal emitted when a message is updated.
-   */
-  get messageUpdated(): ISignal<IChatModel, IMessage> {
-    return this._messageUpdated;
-  }
-
-  /**
-   * The signal emitted when a message is updated.
-   */
-  get messageDeleted(): ISignal<IChatModel, IMessage> {
-    return this._messageDeleted;
-  }
-
-  /**
    * Send a message, to be defined depending on the chosen technology.
    * Default to no-op.
    *
@@ -199,8 +175,6 @@ export class ChatModel implements IChatModel {
   private _config: IConfig;
   private _isDisposed = false;
   private _incomingMessage = new Signal<IChatModel, IMessage>(this);
-  private _messageUpdated = new Signal<IChatModel, IChatMessage>(this);
-  private _messageDeleted = new Signal<IChatModel, IChatMessage>(this);
 }
 
 /**

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -39,7 +39,12 @@ export type IClearMessage = {
   type: 'clear';
 };
 
-export type IMessage = IChatMessage | IClearMessage;
+export type IDeleteMessage = {
+  type: 'remove';
+  id: string;
+};
+
+export type IMessage = IChatMessage | IClearMessage | IDeleteMessage;
 
 /**
  * The chat history interface.

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -32,7 +32,7 @@ export interface IChatMessage {
   body: string;
   id: string;
   time: number;
-  sender: IUser;
+  sender: IUser | string;
 }
 
 export type IClearMessage = {

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -5,17 +5,16 @@
 
 import json
 from functools import partial
-from typing import Any, Callable, List
+from typing import Any, Callable, Dict
 
 from jupyter_ydoc.ybasedoc import YBaseDoc
-from pycrdt import Array, Map
-
+from pycrdt import Map
 
 class YChat(YBaseDoc):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._ydoc["content"] = self._ycontent = Map()
-        self._ydoc["messages"] = self._ymessages = Array()
+        self._ydoc["users"] = self._yusers = Map()
+        self._ydoc["messages"] = self._ymessages = Map()
 
     @property
     def version(self) -> str:
@@ -27,19 +26,44 @@ class YChat(YBaseDoc):
         return "1.0.0"
 
     @property
-    def messages(self) -> List:
+    def users(self) -> Map:
+        return self._yusers.to_py()
+
+    def get_users(self) -> Dict:
+        """
+        Returns the users of the document.
+        :return: Document's users.
+        :rtype: string
+        """
+
+        users = self._yusers.to_py()
+        return dict(users=users)
+
+    @property
+    def messages(self) -> Map:
         return self._ymessages.to_py()
 
-    def get(self) -> str:
+    def get_messages(self) -> Dict:
         """
         Returns the messages of the document.
         :return: Document's messages.
-        :rtype: Any
+        :rtype: string
         """
 
         messages = self._ymessages.to_py()
-        data = dict(messages=messages)
-        return json.dumps(data, indent=2, sort_keys=True)
+        return dict(messages=messages)
+
+    def get(self) -> str:
+        """
+        Returns the contents of the document.
+        :return: Document's contents.
+        :rtype: string
+        """
+
+        return json.dumps({
+            "messages": self.get_messages()["messages"],
+            "users": self.get_users()["users"]
+        })
 
     def set(self, value: str) -> None:
         """
@@ -51,10 +75,15 @@ class YChat(YBaseDoc):
             contents = json.loads(value)
         except json.JSONDecodeError:
             contents = dict()
+        if "users" in contents.keys():
+            with self._ydoc.transaction():
+                for k, v in contents["users"].items():
+                    self._yusers.update({k: v})
+
         if "messages" in contents.keys():
             with self._ydoc.transaction():
-                for v in contents["messages"]:
-                    self._ymessages.append(v)
+                for k, v in contents["messages"].items():
+                    self._ymessages.update({k, v})
 
     def observe(self, callback: Callable[[str, Any], None]) -> None:
         self.unobserve()
@@ -62,4 +91,4 @@ class YChat(YBaseDoc):
         self._subscriptions[self._ymessages] = self._ymessages.observe(
             partial(callback, "messages")
         )
-        self._subscriptions[self._ycontent] = self._ycontent.observe(partial(callback, "content"))
+        self._subscriptions[self._yusers] = self._yusers.observe(partial(callback, "users"))

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -83,7 +83,7 @@ class YChat(YBaseDoc):
         if "messages" in contents.keys():
             with self._ydoc.transaction():
                 for k, v in contents["messages"].items():
-                    self._ymessages.update({k, v})
+                    self._ymessages.update({k: v})
 
     def observe(self, callback: Callable[[str, Any], None]) -> None:
         self.unobserve()

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict
 from jupyter_ydoc.ybasedoc import YBaseDoc
 from pycrdt import Map
 
+
 class YChat(YBaseDoc):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -162,8 +162,8 @@ export class CollaborativeChatModel
       const msgChange = change.messageChanges;
       const messages: IYmessage[] = [];
       msgChange.forEach(data => {
-        // New message
-        if (data.newValue && !data.oldValue) {
+        // New message or updated message.
+        if (data.newValue) {
           messages.push(data.newValue);
         }
       });

--- a/packages/jupyterlab-collaborative-chat/src/ychat.ts
+++ b/packages/jupyterlab-collaborative-chat/src/ychat.ts
@@ -4,7 +4,7 @@
  */
 
 import { IChatMessage, IUser } from '@jupyter/chat';
-import { DocumentChange, StateChange, YDocument } from '@jupyter/ydoc';
+import { DocumentChange, IMapChange, YDocument } from '@jupyter/ydoc';
 import { JSONExt, JSONObject } from '@lumino/coreutils';
 import * as Y from 'yjs';
 
@@ -25,12 +25,12 @@ export type ChatChange = DocumentChange & {
 /**
  * The message change type.
  */
-export type MessageChange = StateChange<IYmessage>;
+export type MessageChange = IMapChange<IYmessage>;
 
 /**
  * The user change type.
  */
-export type UserChange = StateChange<IUser>;
+export type UserChange = IMapChange<IUser>;
 
 /**
  * The interface for a YMessage.
@@ -101,11 +101,30 @@ export class YChat extends YDocument<ChatChange> {
     event.keysChanged.forEach(key => {
       const change = event.changes.keys.get(key);
       if (change) {
-        userChange.push({
-          name: key,
-          oldValue: change.oldValue,
-          newValue: this._users.get(key)
-        });
+        switch (change.action) {
+          case 'add':
+            userChange.push({
+              key,
+              newValue: this._users.get(key),
+              type: 'add'
+            });
+            break;
+          case 'delete':
+            userChange.push({
+              key,
+              oldValue: change.oldValue,
+              type: 'remove'
+            });
+            break;
+          case 'update':
+            userChange.push({
+              key: key,
+              oldValue: change.oldValue,
+              newValue: this._users.get(key),
+              type: 'change'
+            });
+            break;
+        }
       }
     });
 
@@ -117,11 +136,30 @@ export class YChat extends YDocument<ChatChange> {
     event.keysChanged.forEach(key => {
       const change = event.changes.keys.get(key);
       if (change) {
-        messageChanges.push({
-          name: key,
-          oldValue: change.oldValue,
-          newValue: this._messages.get(key)
-        });
+        switch (change.action) {
+          case 'add':
+            messageChanges.push({
+              key,
+              newValue: this._messages.get(key),
+              type: 'add'
+            });
+            break;
+          case 'delete':
+            messageChanges.push({
+              key,
+              oldValue: change.oldValue,
+              type: 'remove'
+            });
+            break;
+          case 'update':
+            messageChanges.push({
+              key: key,
+              oldValue: change.oldValue,
+              newValue: this._messages.get(key),
+              type: 'change'
+            });
+            break;
+        }
       }
     });
 

--- a/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
+++ b/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
@@ -96,10 +96,14 @@ export class WebSocketHandler extends ChatModel {
 
   onMessage(message: IMessage): void {
     // resolve promise from `sendMessage()`
-    if (message.type === 'msg' && message.sender.id === this.id) {
-      this._sendResolverQueue.get(message.id)?.(true);
-    }
+    if (message.type === 'msg') {
+      const sender =
+        typeof message.sender !== 'string' ? message.sender.id : message.sender;
 
+      if (sender === this.id) {
+        this._sendResolverQueue.get(message.id)?.(true);
+      }
+    }
     super.onMessage(message);
   }
 


### PR DESCRIPTION
This PR (1) improve the YChat document:
- add a `users` section in the document, to avoid duplicating the whole user information for each message
- handle remote update of a message (not from the UI)
- should handle message deletion (not from the UI) 

(2) insert message at the correct position in the flow, using the timestamp of the message
